### PR TITLE
Add `version` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 const packageJson = require('package-json');
 
-module.exports = name => packageJson(name.toLowerCase()).then(data => data.version);
+module.exports = (name, version) => packageJson(name.toLowerCase(), version ? {version} : {}).then(data => data.version);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 const packageJson = require('package-json');
 
-module.exports = (name, version) => packageJson(name.toLowerCase(), version ? {version} : {}).then(data => data.version);
+module.exports = (name, opts) => packageJson(name.toLowerCase(), opts).then(data => data.version);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "semver": "^5.4.1",
     "semver-regex": "^1.0.0",
     "xo": "*"
   }

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,8 @@ latestVersion('@sindresorhus/df').then(version => {
 	//=> '1.0.1'
 });
 
-latestVersion('npm', 'latest-5').then(version => {
+// Also works with dist-tags and semver ranges
+latestVersion('npm', {version: 'latest-5'}).then(version => {
 	console.log(version);
 	//=> '5.5.1'
 });

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,11 @@ latestVersion('@sindresorhus/df').then(version => {
 	console.log(version);
 	//=> '1.0.1'
 });
+
+latestVersion('npm', 'latest-5').then(version => {
+	console.log(version);
+	//=> '5.5.1'
+});
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -1,9 +1,18 @@
 import test from 'ava';
+import semver from 'semver';
 import semverRegex from 'semver-regex';
 import m from '.';
 
 test('latest version', async t => {
 	t.regex(await m('ava'), semverRegex());
+});
+
+test('latest version with version', async t => {
+	t.true(semver.satisfies(await m('package-json', '0'), '0.x'));
+});
+
+test('latest version with dist-tag', async t => {
+	t.true(semver.satisfies(await m('npm', 'latest-5'), '5.x'));
 });
 
 test('latest version scoped', async t => {

--- a/test.js
+++ b/test.js
@@ -8,11 +8,11 @@ test('latest version', async t => {
 });
 
 test('latest version with version', async t => {
-	t.true(semver.satisfies(await m('package-json', '0'), '0.x'));
+	t.true(semver.satisfies(await m('package-json', {version: '0'}), '0.x'));
 });
 
 test('latest version with dist-tag', async t => {
-	t.true(semver.satisfies(await m('npm', 'latest-5'), '5.x'));
+	t.true(semver.satisfies(await m('npm', {version: 'latest-5'}), '5.x'));
 });
 
 test('latest version scoped', async t => {


### PR DESCRIPTION
This new feature modifies the signature of the exported function to accept an optional second argument which makes use of `package-json`'s version option (https://github.com/sindresorhus/package-json#version) to allow for checking latest versions of distributions other than `latest`, such as dist-tags and any format supported by the `semver` module.

Examples:

```js
const latestVersion = require('latest-version');

console.log(await latestVersion('npm', 'latest-5'));
//=> '5.5.1'

console.log(await latestVersion('package-json', '3'));
//=> '3.1.0'
```