### PR TITLE
Flag for skipping package name normalization

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,12 @@ declare namespace latestVersion {
 		A semver range or [dist-tag](https://docs.npmjs.com/cli/dist-tag).
 		*/
 		readonly version?: string;
+		/**
+		Whether to normalize the name according to the latest npm rules.
+		New packages are not allowed to use mixed casing, therefore by default package converts the name to lowercase.
+		Set to false if the normalization should be skipped.
+		*/
+		readonly normalizeName?: boolean;
 	}
 }
 
@@ -25,6 +31,10 @@ declare const latestVersion: {
 		// Also works with semver ranges and dist-tags
 		console.log(await latestVersion('npm', {version: 'latest-5'}));
 		//=> '5.5.1'
+
+		// It is possible to skip avoid using lowercase names by using options
+		console.log(await latestVersion('ngVue', {normalizeName: false}));
+		//=> '1.7.8'
 	})();
 	```
 	*/

--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@
 const packageJson = require('package-json');
 
 const latestVersion = async (packageName, options) => {
-	const {version} = await packageJson(packageName.toLowerCase(), options);
+	if (!options || options.normalizeName) {
+		packageName = packageName.toLowerCase();
+	}
+
+	const {version} = await packageJson(packageName, options);
 	return version;
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,3 +3,4 @@ import latestVersion = require('.');
 
 expectType<Promise<string>>(latestVersion('ava'));
 expectType<Promise<string>>(latestVersion('npm', {version: 'latest-5'}));
+expectType<Promise<string>>(latestVersion('ngVue', {normalizeName: false}))

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import {PackageNotFoundError} from 'package-json';
 import test from 'ava';
 import semver from 'semver';
 import semverRegex from 'semver-regex';
@@ -17,4 +18,13 @@ test('latest version with dist-tag', async t => {
 
 test('latest version scoped', async t => {
 	t.regex(await latestVersion('@sindresorhus/df'), semverRegex());
+});
+
+test('latest version with mixed casing (normalize: undefined)', async t => {
+	const error = await t.throwsAsync(latestVersion('ngVue'));
+	t.true(error instanceof PackageNotFoundError);
+});
+
+test('latest version with mixed casing (normalize: false)', async t => {
+	t.regex(await latestVersion('ngVue', {normalizeName: false}), semverRegex());
 });


### PR DESCRIPTION
I understand that npm no longer allows publishing new packages with mixed casing (or uppercase chars at all), but the old packages still exist and they cannot be renamed, that is out of control for consumers of this package.

This change allows them to at least specify options to skip the normalization. If the flag is not necessary, I can remove it and the call for `toLowerCase()` (which, quite frankly, would be an even smaller change).

Fixes #10.