### PR TITLE
types: consider Options type from "package-json" dep

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,4 @@
-export interface Options {
-	/**
-	A semver range or [dist-tag](https://docs.npmjs.com/cli/dist-tag).
-	*/
-	readonly version?: string;
-}
+import type { Options } from 'package-json';
 
 /**
 Get the latest version of an npm package.


### PR DESCRIPTION
To use `registryUrl` and other official options (`package-json` dependency), this PR removes hard-coded `Options` and consider from dependency.  