### PR TITLE
Bump package 'package-json' to fix security vulnerability in sub-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"module"
 	],
 	"dependencies": {
-		"package-json": "^7.0.0"
+		"package-json": "^8.1.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",


### PR DESCRIPTION
Earlier versions of package-json depended on an outdated version of got, which now has a
known security vulnerability (https://github.com/advisories/GHSA-pfrx-2q88-qq97). A fix has been published
for package-json in version 8.0.0.