### PR TITLE
fix: update to patched version of package-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "latest-version",
-	"version": "5.1.0",
+	"version": "5.1.1",
 	"description": "Get the latest version of an npm package",
 	"license": "MIT",
 	"repository": "sindresorhus/latest-version",
@@ -30,7 +30,7 @@
 		"module"
 	],
 	"dependencies": {
-		"package-json": "^6.3.0"
+		"package-json": "^7.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",


### PR DESCRIPTION
Patches [CVE-2022-33987](https://github.com/advisories/GHSA-pfrx-2q88-qq97). react-devtools depends on a non-ESM version of `latest-version` (and `update-notifier`) hence the need for this fix on v5.1.x