### PR TITLE
feat: add registryUrl to options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,10 @@ export type Options = {
 	A semver range or [dist-tag](https://docs.npmjs.com/cli/dist-tag).
 	*/
 	readonly version?: string;
+	/**
+	The registry URL is by default inferred from the npm defaults and `.npmrc`. This is beneficial as `package-json` and any project using it will work just like npm. This option is*only** intended for internal tools. You should __not__ use this option in reusable packages. Prefer just using `.npmrc` whenever possible.
+	*/
+	readonly registryUrl?: string;
 };
 
 /**


### PR DESCRIPTION
registryUrl is actually supported but not mentioned in types. Added it since it can be quite useful for people who use private npm registry.