### PR TITLE
Update `package-json`, expose some options

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 21
           - 20
           - 18
     steps:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,7 @@
-export type Options = {
-	/**
-	A semver range or [dist-tag](https://docs.npmjs.com/cli/dist-tag).
-	*/
-	readonly version?: string;
-};
+import type {Options as PackageJsonOptions} from 'package-json';
+
+// TODO: descriptions say some package-json specific things
+export type Options = Pick<PackageJsonOptions, 'version' | 'registryUrl' | 'omitDeprecated'>;
 
 /**
 Get the latest version of an npm package.
@@ -13,14 +11,14 @@ Get the latest version of an npm package.
 import latestVersion from 'latest-version';
 
 console.log(await latestVersion('ava'));
-//=> '0.18.0'
+//=> '6.1.1'
 
 console.log(await latestVersion('@sindresorhus/df'));
-//=> '1.0.1'
+//=> '4.0.0'
 
 // Also works with semver ranges and dist-tags
 console.log(await latestVersion('npm', {version: 'latest-5'}));
-//=> '5.5.1'
+//=> '5.10.0'
 ```
 */
 export default function latestVersion(packageName: string, options?: Options): Promise<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import type {Options as PackageJsonOptions} from 'package-json';
 
-// TODO: descriptions say some package-json specific things
+export {PackageNotFoundError, VersionNotFoundError} from 'package-json';
+
 export type Options = Pick<PackageJsonOptions, 'version' | 'registryUrl' | 'omitDeprecated'>;
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 import packageJson from 'package-json';
 
+export {PackageNotFoundError, VersionNotFoundError} from 'package-json';
+
 export default async function latestVersion(packageName, options) {
 	const {version} = await packageJson(packageName.toLowerCase(), options);
 	return version;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,3 +3,5 @@ import latestVersion from './index.js';
 
 expectType<Promise<string>>(latestVersion('ava'));
 expectType<Promise<string>>(latestVersion('npm', {version: 'latest-5'}));
+expectType<Promise<string>>(latestVersion('npm', {registryUrl: 'https://registry.yarnpkg.com'}));
+expectType<Promise<string>>(latestVersion('npm', {omitDeprecated: false}));

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
 		"module"
 	],
 	"dependencies": {
-		"package-json": "^9.0.0"
+		"package-json": "^10.0.0"
 	},
 	"devDependencies": {
-		"ava": "^6.1.0",
-		"semver": "^7.5.4",
+		"ava": "^6.1.1",
+		"semver": "^7.6.0",
 		"semver-regex": "^4.0.5",
-		"tsd": "^0.30.4",
-		"xo": "^0.56.0"
+		"tsd": "^0.30.7",
+		"xo": "^0.57.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,14 @@ npm install latest-version
 import latestVersion from 'latest-version';
 
 console.log(await latestVersion('ava'));
-//=> '0.18.0'
+//=> '6.1.1'
 
 console.log(await latestVersion('@sindresorhus/df'));
-//=> '1.0.1'
+//=> '4.0.0'
 
 // Also works with semver ranges and dist-tags
 console.log(await latestVersion('npm', {version: 'latest-5'}));
-//=> '5.5.1'
+//=> '5.10.0'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ console.log(await latestVersion('npm', {version: 'latest-5'}));
 //=> '5.10.0'
 ```
 
+This package exposes the [`version`](https://github.com/sindresorhus/package-json#version), [`registryUrl`](https://github.com/sindresorhus/package-json#registryurl), and [`omitDeprecated`](https://github.com/sindresorhus/package-json#omitdeprecated) options from [`package-json`](https://github.com/sindresorhus/package-json#options), as well as the [`PackageNotFoundError`](https://github.com/sindresorhus/package-json#packagenotfounderror) and [`VersionNotFoundError`](https://github.com/sindresorhus/package-json#versionnotfounderror) errors.
+
 ## Related
 
 - [latest-version-cli](https://github.com/sindresorhus/latest-version-cli) - CLI for this module

--- a/test.js
+++ b/test.js
@@ -18,3 +18,20 @@ test('latest version with dist-tag', async t => {
 test('latest version scoped', async t => {
 	t.regex(await latestVersion('@sindresorhus/df'), semverRegex());
 });
+
+test('registry url', async t => {
+	t.regex(await latestVersion('npm', {registryUrl: 'https://registry.yarnpkg.com/'}), semverRegex());
+});
+
+test('include deprecated', async t => {
+	t.regex(await latestVersion('querystring', {version: '0.2', omitDeprecated: false}), semverRegex());
+});
+
+// TODO: should we expose package-json errors?
+test('throws if not found', async t => {
+	const packageError = await t.throwsAsync(latestVersion('nnnope'));
+	t.is(packageError.name, 'PackageNotFoundError');
+
+	const versionError = await t.throwsAsync(latestVersion('npm', {version: '0.0.0'}));
+	t.is(versionError.name, 'VersionNotFoundError');
+});

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import semver from 'semver';
 import semverRegex from 'semver-regex';
-import latestVersion from './index.js';
+import latestVersion, {PackageNotFoundError, VersionNotFoundError} from './index.js';
 
 test('latest version', async t => {
 	t.regex(await latestVersion('ava'), semverRegex());
@@ -27,11 +27,7 @@ test('include deprecated', async t => {
 	t.regex(await latestVersion('querystring', {version: '0.2', omitDeprecated: false}), semverRegex());
 });
 
-// TODO: should we expose package-json errors?
 test('throws if not found', async t => {
-	const packageError = await t.throwsAsync(latestVersion('nnnope'));
-	t.is(packageError.name, 'PackageNotFoundError');
-
-	const versionError = await t.throwsAsync(latestVersion('npm', {version: '0.0.0'}));
-	t.is(versionError.name, 'VersionNotFoundError');
+	await t.throwsAsync(latestVersion('nnnope'), {instanceOf: PackageNotFoundError});
+	await t.throwsAsync(latestVersion('npm', {version: '0.0.0'}), {instanceOf: VersionNotFoundError});
 });


### PR DESCRIPTION
Closes #25.

Exposes `version`, `registryUrl`, and `omitDeprecated` from `package-json`, as well as the `PackageNotFoundError` and `VersionNotFoundError` errors.